### PR TITLE
Add xiaomi.vacuum.b108gl to supported vacuums list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ parsed_map = parser.parse(unpacked_map)
 ```
   
 ## Supported vacuums:
+- xiaomi.vacuum.b108gl
 - xiaomi.vacuum.e101gb
 - xiaomi.vacuum.ov71gl
 - xiaomi.vacuum.ov31gl


### PR DESCRIPTION
https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues/720 