### PR TITLE
fix: parse fb_regions and fb_walls from Dreame-based Xiaomi models

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ parsed_map = parser.parse(unpacked_map)
 - xiaomi.vacuum.e101gb
 - xiaomi.vacuum.ov71gl
 - xiaomi.vacuum.ov31gl
+- xiaomi.vacuum.ov81gl
 
 *If you got another vacuum to work, please tell us*
 

--- a/src/vacuum_map_parser_xiaomi/map_data_parser.py
+++ b/src/vacuum_map_parser_xiaomi/map_data_parser.py
@@ -447,11 +447,39 @@ class XiaomiMapDataParser(MapDataParser):
         no_go = []  # No-go zones (vacuum won't enter)
         no_mop = []  # No-mopping zones (vacuum can sweep but not mop)
 
+        # fb_attr values used in Dreame-based Xiaomi models (e.g. xiaomi.vacuum.ov81gl)
+        # 1 = no-mopping zone, 2 = no-go zone
+        _FB_ATTR_NO_GO = 2
+        _FB_ATTR_NO_MOP = 1
+
         # fb_regions = "forbidden regions"
+        # Supports two payload formats:
+        #
+        # Format A (generic/future): structured points + type string
+        #   {"points": [{"x": x1, "y": y1}, ...], "type": "no_go"|"no_mop"|"wall"}
+        #
+        # Format B (Dreame-based Xiaomi models, e.g. xiaomi.vacuum.ov81gl):
+        #   {"id": N, "fb_attr": 1|2, "fb_point": [x1, y1, x2, y2, x3, y3, x4, y4]}
+        #   where fb_attr: 1=no_go, 2=no_mop
         for area in payload.get("fb_regions", []) or []:
             if not isinstance(area, dict):
                 continue
 
+            # Format B: flat coordinate list in fb_point
+            fb_point = area.get("fb_point")
+            if fb_point is not None:
+                if not isinstance(fb_point, list) or len(fb_point) != 8:
+                    continue
+                x1, y1, x2, y2, x3, y3, x4, y4 = fb_point
+                fb_attr = area.get("fb_attr", _FB_ATTR_NO_GO)
+                region = Area(x1, y1, x2, y2, x3, y3, x4, y4)
+                if fb_attr == _FB_ATTR_NO_GO:
+                    no_go.append(region)
+                elif fb_attr == _FB_ATTR_NO_MOP:
+                    no_mop.append(region)
+                continue
+
+            # Format A: structured points list
             pts = area.get("points")
             if not pts or len(pts) != 4:
                 continue
@@ -470,6 +498,18 @@ class XiaomiMapDataParser(MapDataParser):
             elif atype == "no_mop":
                 # No-mopping zones use the same format as no-go zones
                 no_mop.append(Area(p[0].x, p[0].y, p[1].x, p[1].y, p[2].x, p[2].y, p[3].x, p[3].y))
+
+        # fb_walls = virtual wall lines (separate from fb_regions in Dreame-based models)
+        # Format: {"id": N, "wall_points": [x1, y1, x2, y2]}
+        for wall in payload.get("fb_walls", []) or []:
+            if not isinstance(wall, dict):
+                continue
+            wall_pts = wall.get("wall_points")
+            if not isinstance(wall_pts, list) or len(wall_pts) != 4:
+                _LOGGER.debug("fb_walls entry has unexpected wall_points: %s", wall_pts)
+                continue
+            x1, y1, x2, y2 = wall_pts
+            walls.append(Wall(x1, y1, x2, y2))
 
         map_data.walls = walls
         map_data.no_go_areas = no_go

--- a/src/vacuum_map_parser_xiaomi/map_data_parser.py
+++ b/src/vacuum_map_parser_xiaomi/map_data_parser.py
@@ -448,8 +448,10 @@ class XiaomiMapDataParser(MapDataParser):
         no_mop = []  # No-mopping zones (vacuum can sweep but not mop)
 
         # fb_attr values used in Dreame-based Xiaomi models (e.g. xiaomi.vacuum.ov81gl)
-        # 1 = no-mopping zone, 2 = no-go zone
-        _FB_ATTR_NO_GO = 2
+        # Verified against real device data:
+        #   0 = no-go zone
+        #   1 = no-mopping zone
+        _FB_ATTR_NO_GO = 0
         _FB_ATTR_NO_MOP = 1
 
         # fb_regions = "forbidden regions"
@@ -459,8 +461,8 @@ class XiaomiMapDataParser(MapDataParser):
         #   {"points": [{"x": x1, "y": y1}, ...], "type": "no_go"|"no_mop"|"wall"}
         #
         # Format B (Dreame-based Xiaomi models, e.g. xiaomi.vacuum.ov81gl):
-        #   {"id": N, "fb_attr": 1|2, "fb_point": [x1, y1, x2, y2, x3, y3, x4, y4]}
-        #   where fb_attr: 1=no_go, 2=no_mop
+        #   {"id": N, "fb_attr": 0|1, "fb_point": [x1, y1, x2, y2, x3, y3, x4, y4]}
+        #   where fb_attr: 0=no_go, 1=no_mop
         for area in payload.get("fb_regions", []) or []:
             if not isinstance(area, dict):
                 continue


### PR DESCRIPTION
Dreame-based Xiaomi vacuums (e.g. xiaomi.vacuum.ov81gl) encode forbidden regions and virtual walls using a different JSON format than what the parser previously expected:

- fb_regions: flat coordinate list in fb_point [x1,y1,x2,y2,x3,y3,x4,y4] with fb_attr indicating type (1=no_mop, 2=no_go)
- fb_walls: separate key with wall_points [x1,y1,x2,y2]

The existing Format A (structured points + type string) is preserved for compatibility with other models. Format B is now detected via presence of the fb_point key and handled accordingly.

Verified against real map data from xiaomi.vacuum.ov81gl:
- 2 no-mopping areas (fb_attr=1) parsed correctly
- 5 virtual walls (fb_walls) parsed correctly

Close #3 

*disclaimer*
*I used Claude Code to implement the fix, although reviewing whatever was modified. I've tested the change with my vacuum and seems to be working as expecte. I'm using it in Home Assistant, with the Map extractor integration. The map now loads the virtual walls and no-go or no-mop areas, and respect them to avoid getting into zones that should't. Although I can not test that this is not breaking the compatibility with other models.*

Happy to apply any feedback, keep in mind that I haven't read entirely the parse, so, maybe it's better to apply the logic in a different place.